### PR TITLE
Add SUSY-HIT

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,15 +25,15 @@ rec {
               };
 
 
-      CheckMATE     = callPackage ./pkgs/CheckMATE { 
+      CheckMATE     = callPackage ./pkgs/CheckMATE {
                         inherit root5;
                       };
 
-      CheckMATEEnv  = callPackage ./pkgs/CheckMATE/env.nix { 
+      CheckMATEEnv  = callPackage ./pkgs/CheckMATE/env.nix {
                         inherit CheckMATE;
                       };
 
-      Delphes       = callPackage ./pkgs/Delphes { 
+      Delphes       = callPackage ./pkgs/Delphes {
                         inherit root5;
                       };
 
@@ -69,7 +69,7 @@ rec {
       MadAnalysis5Env  = callPackage ./pkgs/MadAnalysis5/env.nix {
                            inherit MadAnalysis5 root5 FastJet Delphes;
                          };
-                     
+
 
       MadGraph5_aMCatNLO = callPackage ./pkgs/MadGraph5_aMCatNLO {
                              inherit pythia-pgs PYTHIA8 ; # PYTHIA8-src-unpacked;
@@ -90,7 +90,6 @@ rec {
       #                         inherit PYTHIA8-src;
       #                       };
 
-
       PYTHIA8       = callPackage ./pkgs/PYTHIA8 {
                         inherit PYTHIA8-src HepMC;
                       };
@@ -101,12 +100,13 @@ rec {
 
       ROOT6         = callPackage ./pkgs/ROOT6 { };
 
-      ROOT6Env      = callPackage ./pkgs/ROOT6/env.nix { 
-                        inherit ROOT6; 
+      ROOT6Env      = callPackage ./pkgs/ROOT6/env.nix {
+                        inherit ROOT6;
                       };
 
-
       SHERPA        = callPackage ./pkgs/SHERPA { };
+
+      SUSY-HIT      = callPackage ./pkgs/SUSY-HIT { };
 
       ThePEG        = callPackage ./pkgs/ThePEG {
                         stdenv = let clang33Stdenv = overrideGCC stdenv clang_33;

--- a/pkgs/SUSY-HIT/default.nix
+++ b/pkgs/SUSY-HIT/default.nix
@@ -1,0 +1,33 @@
+{ pkgs, stdenv, fetchurl }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "SUSY-HIT-${version}";
+  version = "1.4";
+  src = fetchurl {
+    url = "http://www.itp.kit.edu/~maggie/SUSY-HIT/susyhit.tar.gz";
+    sha256 = "0y4vdrzv9kwikyhs1zm6csp57l5i9dkcp8hrbmqaxcs1r13wcf04";
+  };
+  buildInputs = [ gfortran ];
+
+  unpackPhase = ''
+    mkdir -p susyhit
+    tar zxf $src -C susyhit
+  '';
+
+  buildPhase = ''
+    cd susyhit
+    make
+  '';
+
+  installPhase = ''
+    cd ..
+    tar czf susyhit-${version}.tar.gz susyhit/run susyhit/*.in
+    mkdir -p $out/share/SUSY-HIT-${version}
+    cp susyhit-${version}.tar.gz $out/share/SUSY-HIT-${version}
+  '';
+
+  meta = {
+  };
+}


### PR DESCRIPTION
This adds [SUSY-HIT](http://www.itp.kit.edu/~maggie/SUSY-HIT/), which calculates particle spectrum and the decay widths and branching ratios of the Higgs bosons and supersymmetric particles.

There is one executable, `run`, and some input files. Since the executable only reads the input file in the same directory, it provides a `susyhit-1.4.tar.gz`, where the executable and the input files are contained all together.

It has been tested on both OS X and Linux.
