### PR TITLE
Add LanHEP

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,3 @@
-
 { pkgs } :
 
 with pkgs;
@@ -63,6 +62,10 @@ rec {
 
       HepMC         = callPackage ./pkgs/HepMC { };
 
+      LanHEP        = callPackage ./pkgs/LanHEP { };
+
+      LanHEPEnv     = callPackage ./pkgs/LanHEP/env.nix { inherit LanHEP; };
+
       LHAPDF        = callPackage ./pkgs/LHAPDF { };
 
       MadAnalysis5  = callPackage ./pkgs/MadAnalysis5 { };
@@ -70,7 +73,6 @@ rec {
       MadAnalysis5Env  = callPackage ./pkgs/MadAnalysis5/env.nix {
                            inherit MadAnalysis5 root5 FastJet Delphes;
                          };
-
 
       MadGraph5_aMCatNLO = callPackage ./pkgs/MadGraph5_aMCatNLO {
                              inherit pythia-pgs PYTHIA8 ; # PYTHIA8-src-unpacked;

--- a/pkgs/LanHEP/default.nix
+++ b/pkgs/LanHEP/default.nix
@@ -1,0 +1,27 @@
+{ pkgs, fetchurl }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "LanHEP-${version}";
+  version = "3.1.9";
+  src = fetchurl {
+    url = "http://theory.sinp.msu.ru/~semenov/lhep319.tgz";
+    sha256 = "0k2finn3slgacb6jb51n92gs0xj1acqhy2bkpg14aaszhwhcnaqw";
+  };
+  buildInputs = [ ];
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    cd ..
+    tar czf ${name}.tar.gz $sourceRoot/lhep $sourceRoot/SLHAplus $sourceRoot/manuals $sourceRoot/mdl $sourceRoot/minsusy $sourceRoot/susy8 $sourceRoot/susyLHA $sourceRoot/test
+    mkdir -p $out/share/${name}
+    cp ${name}.tar.gz $out/share/${name}
+  '';
+
+  meta = {
+  };
+}

--- a/pkgs/LanHEP/env.nix
+++ b/pkgs/LanHEP/env.nix
@@ -1,0 +1,15 @@
+{ pkgs, LanHEP }:
+
+let version = LanHEP.version;
+in pkgs.myEnvFun rec {
+  name = "LanHEP-${version}";
+
+  buildInputs = with pkgs; [ ];
+
+  extraCmds = with pkgs; ''
+    unpack () {
+      tar xzf ${LanHEP}/share/${name}/${name}.tar.gz
+    }
+    export -f unpack
+  '';
+}


### PR DESCRIPTION
This adds [LanHEP](http://theory.sinp.msu.ru/~semenov/lanhep.html), which is the program for Feynman rules generation in momentum representation.

It provides a tarball that includes the executable `lhep` and other resources for using in run time. The environment, `LanHEPEnv`, gives the `unpack` function to extract the tarball.
