### PR TITLE
Disable parallel building for SPheno

### DIFF
--- a/pkgs/SPheno/default.nix
+++ b/pkgs/SPheno/default.nix
@@ -1,22 +1,20 @@
-{ stdenv, fetchurl, pkgs}: 
+{ stdenv, fetchurl, pkgs }:
 
-stdenv.mkDerivation rec { 
-  name = "SPheno-${version}"; 
+stdenv.mkDerivation rec {
+  name = "SPheno-${version}";
   version = "3.3.2";
-  src = fetchurl { 
+  src = fetchurl {
     url = "http://www.hepforge.org/archive/spheno/SPheno-3.3.2.tar.gz";
     sha256 = "11cffr8lwcwaf62mg5c5asg7sn6jdra9dxapw2fj48fc3kx1fxwd";
   };
   patches = [ ./use-gfortran.patch ];
   buildInputs = [ pkgs.gfortran ];
-  enableParallelBuilding = true; 
-  
-  installPhase = ''
-  ensureDir $out
-  cp -r bin doc lib include input output $out
-  '';
-  
-  dontFixup = true;
+  enableParallelBuilding = false;
 
-  #configureFlags = "--enable-allcxxplugins " ; 
+  installPhase = ''
+    ensureDir $out
+    cp -r bin doc lib include input output $out
+  '';
+
+  dontFixup = true;
 }


### PR DESCRIPTION
This fixes the compilation failure due to the parallel building.
