### PR TITLE
Add FeynHiggs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -49,6 +49,8 @@ rec {
                       inherit Fastlim;
                     };
 
+      FeynHiggs     = callPackage ./pkgs/FeynHiggs { };
+
       HERWIGpp      = callPackage ./pkgs/HERWIGpp {
                         stdenv = let clang33Stdenv = overrideGCC stdenv clang_33;
                                  in if stdenv.isDarwin then clang33Stdenv else stdenv;

--- a/pkgs/FeynHiggs/default.nix
+++ b/pkgs/FeynHiggs/default.nix
@@ -1,0 +1,21 @@
+{ stdenv, fetchurl, pkgs }:
+
+stdenv.mkDerivation rec {
+  name = "FeynHiggs-${version}";
+  version = "2.10.2";
+  src = fetchurl {
+    url = "http://wwwth.mpp.mpg.de/members/heinemey/feynhiggs/newversion/FeynHiggs-2.10.2.tar.gz";
+    sha256 = "1977jnxp9a43kf5qndcxap05wpi028v6bx27xx5qhbqv0di23mjq";
+   };
+  buildInputs = [ pkgs.gfortran pkgs.which ];
+  enableParallelBuilding = true;
+
+  preConfigure = ''
+    substituteInPlace configure --replace /bin/sh ${pkgs.bash}/bin/bash
+  '';
+
+  configureFlags = if stdenv.isDarwin then "--64" else "";
+
+  meta = {
+  };
+}


### PR DESCRIPTION
This adds [FeynHiggs](http://www.feynhiggs.de), which is a Fortran code for the diagrammatic calculation of the masses, mixings and much more of the Higgs bosons in the MSSM at the two-loop level.
