### PR TITLE
Add CalcHEP

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,8 +22,9 @@ rec {
                         inherit Atom;
                         inherit root5;
                         inherit HepMC YODA FastJet;
-              };
+                      };
 
+      CalcHEP       = callPackage ./pkgs/CalcHEP { };
 
       CheckMATE     = callPackage ./pkgs/CheckMATE {
                         inherit root5;

--- a/pkgs/CalcHEP/default.nix
+++ b/pkgs/CalcHEP/default.nix
@@ -1,0 +1,23 @@
+{ pkgs, stdenv, fetchurl, libX11, gfortran }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "CalcHEP-${version}";
+  version = "3.6.15";
+  src = fetchurl {
+    url = "http://theory.sinp.msu.ru/~pukhov/CALCHEP/calchep_3.6.15.tgz";
+    sha256 = "0mhpyxlh2qvg2yl329db1vg8cnydj32046hbxyppc0kggpwx4n2z";
+  };
+  patches = [ ];
+  buildInputs = [ gfortran libX11 which ];
+  enableParallelBuilding = false;
+
+  installPhase = ''
+    sed "2s,.*,CALCHEP=$out," mkWORKdir > mkWORKdir_patched
+    mv mkWORKdir_patched mkWORKdir
+    chmod 755 mkWORKdir
+    mkdir -p $out
+    cp -r * $out
+  '';
+}


### PR DESCRIPTION
This adds [CalcHEP](http://theory.sinp.msu.ru/~pukhov/calchep.html). We may have to think about how to write `env.nix` as was discussed in the [issue](https://github.com/wavewave/hep-nix-overlay/issues/11).
