### PR TITLE
Add ColorFull

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,8 @@ rec {
                         inherit CheckMATE;
                       };
 
+      ColorFull     = callPackage ./pkgs/ColorFull { };
+
       Delphes       = callPackage ./pkgs/Delphes {
                         inherit root5;
                       };

--- a/pkgs/ColorFull/default.nix
+++ b/pkgs/ColorFull/default.nix
@@ -1,0 +1,14 @@
+{ stdenv, fetchurl }:
+
+stdenv.mkDerivation rec {
+  name = "ColorFull-${version}";
+  version = "0.99";
+  src = fetchurl {
+    url = "http://colorfull.hepforge.org/ColorFull-0.99.tar.gz";
+    sha256 = "1wdvg3kmn1xb9gppg9al7x2h9iw4la7xqml2hn1fi4v9bvf8by6v";
+  };
+  enableParallelBuilding = true;
+
+  meta = {
+  };
+}


### PR DESCRIPTION
This adds [ColorFull](http://colorfull.hepforge.org), which is a C++ code for calculations in QCD (SU(Nc)) color space.

It has been tested on Linux.