### PR TITLE
Update LanHEP

### DIFF
--- a/pkgs/LanHEP/compiler.patch
+++ b/pkgs/LanHEP/compiler.patch
@@ -1,0 +1,13 @@
+diff -rupN a/Makefile b/Makefile
+--- a/Makefile	2013-06-24 08:23:05.000000000 +0900
++++ b/Makefile	2015-02-07 16:12:39.000000000 +0900
+@@ -1,7 +1,7 @@
+ LOPT = -O2
+ CFLAGS =  -O2
+-CC = gcc
+-LD = gcc
++CC = cc
++LD = cc
+ LIB =  -lm -ldl
+ Output = OutputNotSet
+ 

--- a/pkgs/LanHEP/default.nix
+++ b/pkgs/LanHEP/default.nix
@@ -4,12 +4,13 @@ with pkgs;
 
 stdenv.mkDerivation rec {
   name = "LanHEP-${version}";
-  version = "3.1.9";
+  version = "3.2.0";
   src = fetchurl {
-    url = "http://theory.sinp.msu.ru/~semenov/lhep319.tgz";
-    sha256 = "0k2finn3slgacb6jb51n92gs0xj1acqhy2bkpg14aaszhwhcnaqw";
+    url = "http://theory.sinp.msu.ru/~semenov/lhep320.tgz";
+    sha256 = "17bqgva75zi7wjkhw1lzakr5m89p60lrq7x78v7kbgni2yyqa2jb";
   };
   buildInputs = [ ];
+  patches = [ ./compiler.patch ];
 
   buildPhase = ''
     make


### PR DESCRIPTION
This updates LanHEP. It has been successfully tested on both Linux and OS X after applying the patch on the compiler and the linker in `Makefile`.