### PR TITLE
Update softsusy (v3.5.2)

### DIFF
--- a/pkgs/softsusy/default.nix
+++ b/pkgs/softsusy/default.nix
@@ -1,12 +1,13 @@
-{ stdenv, fetchurl, pkgs}: 
+{ stdenv, fetchurl, pkgs }:
 
-stdenv.mkDerivation rec { 
-  name = "softsusy-${version}"; 
-  version = "3.4.1";
-  src = fetchurl { 
-    url = "http://www.hepforge.org/archive/softsusy/softsusy-3.4.1.tar.gz";
-    sha256 = "1s94gkksb1xyky1bhgcz1qfhl045ygk190i9gm487pq3ixkajv8a";
+stdenv.mkDerivation rec {
+  name = "softsusy-${version}";
+  version = "3.5.2";
+  src = fetchurl {
+    url = "http://www.hepforge.org/archive/softsusy/softsusy-3.5.2.tar.gz";
+    sha256 = "06mm4yk2pg6qg00fzmi7a834yh6vv292qcvyksk3cyd1q1y93qvh";
   };
   buildInputs = [ pkgs.gfortran ];
-  enableParallelBuilding = true; 
+  patches = [ ./remove_dupl_output.patch ];
+  enableParallelBuilding = true;
 }

--- a/pkgs/softsusy/env.nix
+++ b/pkgs/softsusy/env.nix
@@ -1,7 +1,6 @@
 { pkgs, softsusy }:
- 
-pkgs.myEnvFun { 
+
+pkgs.myEnvFun {
   name = "softsusy-${softsusy.version}";
   buildInputs = with pkgs; [ softsusy ];
-  
 }

--- a/pkgs/softsusy/remove_dupl_output.patch
+++ b/pkgs/softsusy/remove_dupl_output.patch
@@ -1,0 +1,12 @@
+diff -rupN a/Makefile.in b/Makefile.in
+--- a/Makefile.in	2015-01-22 23:15:30.000000000 +0900
++++ b/Makefile.in	2015-02-07 18:55:43.092868760 +0900
+@@ -635,7 +635,7 @@ src/tensor.cpp src/rpvsusypars.cpp src/r
+ 
+ libsoft_la_LDFLAGS = @FLIBS@
+ @COMPILE_FULL_SUSY_THRESHOLD_FALSE@TESTOUTPUT = inOutFiles/slha2Output inOutFiles/lesHouchesOutput inOutFiles/rpvHouchesOutput \
+-@COMPILE_FULL_SUSY_THRESHOLD_FALSE@inOutFiles/nmssmSLHAZ3Output inOutFiles/nmssmSLHAnoZ3Output inOutFiles/lesHouchesOutput
++@COMPILE_FULL_SUSY_THRESHOLD_FALSE@inOutFiles/nmssmSLHAZ3Output inOutFiles/nmssmSLHAnoZ3Output
+ 
+ @COMPILE_FULL_SUSY_THRESHOLD_FALSE@INPUTFILES = inOutFiles/slha2Input inOutFiles/rpvHouchesInput \
+ @COMPILE_FULL_SUSY_THRESHOLD_FALSE@inOutFiles/nmssmSLHAZ3Input inOutFiles/nmssmSLHAnoZ3Input \


### PR DESCRIPTION
SOFTSUSY has been updated. Now, the most current version is 3.5.2.

It has been successfully tested on Linux, but failed on OS X because gfortran fails to build. It was already reported in the issues in nixpkgs, see [nixpkgs.gcc fails to build on OS X](https://github.com/NixOS/nixpkgs/issues/6148).

The patch is necessary in `installPhase`. It removes the duplication of the file, `lesHouchesOutput`, which would be moved to `share/softsusy`.