### PR TITLE
Update and fix CheckMATE

### DIFF
--- a/pkgs/CheckMATE/default.nix
+++ b/pkgs/CheckMATE/default.nix
@@ -1,26 +1,21 @@
 { pkgs, fetchurl, root5 }:
- 
 
-pkgs.stdenv.mkDerivation rec { 
-  name = "CheckMATE-${version}"; 
-  version = "1.1.10";
-  src = fetchurl { 
-    url = "http://www.hepforge.org/archive/checkmate/CheckMATE-1.1.10.tar.gz";
-    sha256 = "0yw0y03bdvw33xx3nkkdy2fn3y6sv0lazbq8swy1c3cpd0y0x3lx";
+pkgs.stdenv.mkDerivation rec {
+  name = "CheckMATE-${version}";
+  version = "1.1.16";
+  src = fetchurl {
+    url = "http://www.hepforge.org/archive/checkmate/CheckMATE-1.1.16.tar.gz";
+    sha256 = "1hd205h7k5ri2svbm3n2v8xi1fzjg294ilpkj4i6s517nrf9fa8n";
   };
-  buildInputs = [ root5 pythonCheckMATE pkgs.which pkgs.tcl ];
-  enableParallelBuilding = true; 
+  buildInputs = [ root5 ] ++ (with pkgs; [ which tcl python pythonPackages.numpy]);
+  enableParallelBuilding = true;
 
-  pythonCheckMATE = pkgs.pythonFull.override { 
-                      extraLibs = with pkgs.pythonPackages; [ numpy ];
-                    };
-
-  installPhase = ''        
+  installPhase = ''
     cd ..
     tar cvzf CheckMATE-${version}.tar.gz $sourceRoot
     mkdir -p $out/share/CheckMATE-${version}
     cp CheckMATE-${version}.tar.gz $out/share/CheckMATE-${version}
     mkdir -p $out/lib
     cp $sourceRoot/tools/delphes/Delphes-3.0.10X/libDelphes.so $out/lib
-  ''; 
+  '';
 }

--- a/pkgs/CheckMATE/env.nix
+++ b/pkgs/CheckMATE/env.nix
@@ -1,18 +1,17 @@
-{ pkgs, CheckMATE }: 
+{ pkgs, CheckMATE, python, pythonPackages }:
 
 let version = CheckMATE.version;
-in pkgs.myEnvFun rec { 
+in pkgs.myEnvFun rec {
   name = "CheckMATE-${version}";
 
-  buildInputs = with pkgs; [ CheckMATE.pythonCheckMATE ];
-  
+  buildInputs = [ python ] ++ (with pythonPackages; [ numpy ]);
+
   extraCmds = with pkgs; ''
     export PYTHONPATH=
     export LD_LIBRARY_PATH=${CheckMATE}/lib
-    unpack () { 
+    unpack () {
       tar xvzf ${CheckMATE}/share/CheckMATE-${version}/CheckMATE-${version}.tar.gz
     }
-    export -f unpack 
+    export -f unpack
   '';
 }
-


### PR DESCRIPTION
This updates `CheckMATE` into the version 1.1.16 and fix the dependency on Python. It was only tested on Linux.