### PR TITLE
Fix YODA (checking boost headers)

### DIFF
--- a/pkgs/YODA/default.nix
+++ b/pkgs/YODA/default.nix
@@ -1,21 +1,19 @@
 { stdenv, fetchurl, boost, python }:
- 
-stdenv.mkDerivation rec { 
-  name = "YODA-${version}"; 
+
+stdenv.mkDerivation rec {
+  name = "YODA-${version}";
   version = "1.3.0";
 
-  src = fetchurl { 
-    url = "http://www.hepforge.org/archive/yoda/YODA-1.3.0.tar.gz";
-    sha256 = "052syrhwxbrcj2q1qs171cv8hblvs9xla8rkcwy8bzdaqdnia3rj";
+  src = fetchurl {
+    url = "http://www.hepforge.org/archive/yoda/YODA-1.3.0.tar.bz2";
+    sha256 = "05fj5cqq06qdb2pcqqdd5krqi4xlq3ch6iyg0v5iwj0bjkarfcfn";
   };
 
   buildInputs = [ boost python ];
-  enableParallelBuilding = true; 
+  enableParallelBuilding = true;
 
-  configureFlags = "--with-boost=${boost}";
+  configureFlags = "--with-boost=${boost.dev}";
 
-  meta = { 
-
+  meta = {
   };
-
 }


### PR DESCRIPTION
This fixes `YODA`. The boost headers are in `${boost.dev}`, not in `${boost}` (Similarly, the boost libraries are in `${boost.lib}`). I found that the build is successful on both Linux and OS X.