### PR TITLE
Add LHAPDF6

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -75,6 +75,8 @@ rec {
 
       LHAPDF        = callPackage ./pkgs/LHAPDF { };
 
+      LHAPDF6       = callPackage ./pkgs/LHAPDF6 { };
+
       MadAnalysis5  = callPackage ./pkgs/MadAnalysis5 { };
 
       MadAnalysis5Env  = callPackage ./pkgs/MadAnalysis5/env.nix {

--- a/pkgs/LHAPDF6/default.nix
+++ b/pkgs/LHAPDF6/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, fetchurl, python, boost }:
+
+stdenv.mkDerivation rec {
+  name = "LHAPDF6-${version}";
+  version = "6.1.5";
+  src = fetchurl {
+    url = "http://www.hepforge.org/archive/lhapdf/LHAPDF-6.1.5.tar.gz";
+    sha256 = "0c9jz2zgmlqx8d4cpi25k6plw7aka4nnmjr8dfb6qf1aqg0zlpgf";
+  };
+  buildInputs = [ python boost ];
+  enableParallelBuilding = true;
+
+  configureFlags = "--with-boost=${boost.dev}";
+
+  meta = {
+  };
+}


### PR DESCRIPTION
This adds [LHAPDF6](https://lhapdf.hepforge.org), which does not need Fortran any more. Instead, it needs `boost`. It seems that the authors are taking care of the backward compatibility. See [here](https://indico.cern.ch/event/244768/session/2/contribution/16/material/slides/0.pdf). We can test this with other softwares that depend on LHAPDF such as Pythia 8.

It was successfully tested on both Linux and OS X.