### PR TITLE
Use cmake for HepMC

### DIFF
--- a/pkgs/HepMC/default.nix
+++ b/pkgs/HepMC/default.nix
@@ -1,16 +1,18 @@
-{ stdenv, fetchurl, m4, automake, autoconf, libtool }: 
+{ stdenv, fetchurl, cmake }:
 
-stdenv.mkDerivation rec { 
-  name = "HepMC-${version}"; 
+stdenv.mkDerivation rec {
+  name = "HepMC-${version}";
   version = "2.06.08";
-  src = fetchurl { 
+  src = fetchurl {
     url = "http://lcgapp.cern.ch/project/simu/HepMC/download/HepMC-2.06.08.tar.gz";
     sha256 = "1km8m0xkx6igz2rp5yvm5sjnczny8r5vd2xqvl3my10a7rww3rlb";
   };
-  nativeBuildInputs = [ m4 autoconf automake libtool ]; 
-  patches = [ ./no-doc-gen.patch ];
-  configureFlags = "--with-momentum=GEV --with-length=MM --enable-static";
-  preConfigure = ''
-sh ${./preconfigure.sh} 
-'';
+  patches = [ ./in_source_error.patch ];
+  buildInputs = [ cmake ];
+  enableParallelBuilding = true;
+
+  cmakeFlags = [
+    "-Dmomentum:STRING=GEV"
+    "-Dlength:STRING=MM"
+  ];
 }

--- a/pkgs/HepMC/in_source_error.patch
+++ b/pkgs/HepMC/in_source_error.patch
@@ -1,0 +1,25 @@
+diff -rupN a/CMakeLists.txt b/CMakeLists.txt
+--- a/CMakeLists.txt	2012-02-14 07:19:45.000000000 +0900
++++ b/CMakeLists.txt	2015-02-10 01:06:57.000000000 +0900
+@@ -37,21 +37,6 @@ message(STATUS "default momentum and len
+ # find the HepMC cmake modules
+ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})
+ 
+-# make sure we are not building from within the source code directory
+-string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_BINARY_DIR}" in_source)
+-string( REGEX MATCH "${CMAKE_SOURCE_DIR}/" in_source_subdir
+-"${CMAKE_BINARY_DIR}")
+-if (in_source OR in_source_subdir)
+-  message(FATAL_ERROR "
+-ERROR: In source builds of this project are not allowed.
+-A separate build directory is required.
+-Please create one and run cmake from the build directory.
+-Also note that cmake has just added files to your source code directory.
+-We suggest getting a new copy of the source code.
+-Otherwise, delete `CMakeCache.txt' and the directory `CMakeFiles'.
+-  ")
+-endif ()
+-
+ # build_docs is OFF (false) by default
+ if ( build_docs )
+    message(STATUS "documents WILL be built and installed" )


### PR DESCRIPTION
I found that HepMC failed to build in my Linux machine. The problem is due to the incompatible autotools version, in particular `libtool`. For your information, I'm using the binaries from the nixpkgs in Linux, where nixpkgs has been recently re-installed.

This is to use cmake instead of autotools. One subtlety is that the authors disallowed to build inside the source directory. I tested by removing that, and found in-source build does not matter. It was also checked in OS X.