### PR TITLE
Use LHAPDF6 for PYTHIA8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -103,11 +103,11 @@ rec {
       #                       };
 
       PYTHIA8       = callPackage ./pkgs/PYTHIA8 {
-                        inherit PYTHIA8-src HepMC LHAPDF;
+                        inherit PYTHIA8-src HepMC LHAPDF6;
                       };
 
       PYTHIA8Env    = callPackage ./pkgs/PYTHIA8/env.nix {
-                        inherit PYTHIA8 FastJet LHAPDF;
+                        inherit PYTHIA8 FastJet LHAPDF6;
                       };
 
       ROOT6         = callPackage ./pkgs/ROOT6 { };

--- a/pkgs/PYTHIA8/default.nix
+++ b/pkgs/PYTHIA8/default.nix
@@ -1,17 +1,17 @@
-{ pkgs, PYTHIA8-src, HepMC, LHAPDF }:
- 
-pkgs.stdenv.mkDerivation rec { 
-  name = "PYTHIA8-${version}"; 
-  version = "180";
+{ pkgs, PYTHIA8-src, HepMC, LHAPDF6 }:
+
+pkgs.stdenv.mkDerivation rec {
+  name = "PYTHIA8-${version}";
+  version = "186";
   src = PYTHIA8-src;
-  buildInputs = [ HepMC LHAPDF ];
-  enableParallelBuilding = true; 
-   
+  buildInputs = [ HepMC LHAPDF6 ];
+  enableParallelBuilding = true;
+
   preConfigure = ''
     substituteInPlace configure --replace /bin/sh ${pkgs.bash}/bin/bash
   '';
 
-  configureFlags = "--with-hepmc=${HepMC} --with-hepmcversion=${HepMC.version}"; 
+  configureFlags = "--with-hepmc=${HepMC} --with-hepmcversion=${HepMC.version}";
 }
 
 

--- a/pkgs/PYTHIA8/env.nix
+++ b/pkgs/PYTHIA8/env.nix
@@ -1,30 +1,29 @@
-{ pkgs, PYTHIA8, FastJet, LHAPDF }: 
+{ pkgs, PYTHIA8, FastJet, LHAPDF6 }:
 
 let pythia8srcunpacked = import ./src-unpacked.nix { PYTHIA8-src = PYTHIA8.src; stdenv = pkgs.stdenv; };
     version = PYTHIA8.version;
-in pkgs.myEnvFun rec { 
+in pkgs.myEnvFun rec {
   name = "PYTHIA8-${version}";
-  buildInputs = with pkgs; [ PYTHIA8 FastJet LHAPDF pkgs.gfortran ];
+  buildInputs = with pkgs; [ PYTHIA8 FastJet LHAPDF6 ];
 
   extraCmds = with pkgs; ''
     export PYTHIA8LOCATION=${PYTHIA8}
     export FASTJETLOCATION=${FastJet}
-    export LHAPDFLOCATION=${LHAPDF}
+    export LHAPDFLOCATION=${LHAPDF6}/lib
     export LHAPDFLIBNAME="-lLHAPDF"
     export PYTHIA8=${PYTHIA8}
     export PYTHIA8DATA=${PYTHIA8}/xmldoc
-    unpack () { 
+    unpack () {
       mkdir pythia8examples
-      cp -a ${pythia8srcunpacked}/examples pythia8examples     
+      cp -a ${pythia8srcunpacked}/examples pythia8examples
       cp -a ${pythia8srcunpacked}/rootexamples pythia8examples
       chmod -R u+w pythia8examples
     }
-    export -f unpack 
-  ''; 
+    export -f unpack
+  '';
 }
 
 #      echo "${pythia8srcunpacked}"
 # writeScript
     #export LD_LIBRARY_PATH=${LHAPDF}/lib
     #export DYLD_LIBRARY_PATH=${LHAPDF}/lib
-

--- a/pkgs/PYTHIA8/lhapdf6.patch
+++ b/pkgs/PYTHIA8/lhapdf6.patch
@@ -1,0 +1,32 @@
+diff -rupN a/examples/Makefile b/examples/Makefile
+--- a/examples/Makefile	2014-07-09 05:51:14.000000000 +0900
++++ b/examples/Makefile	2015-02-09 22:43:34.000000000 +0900
+@@ -64,8 +64,7 @@ main51 main52 main53 main54: $(PYTHIA8LO
+ 	@mkdir -p $(BINDIR)
+ 	$(CXX) $(CXXFLAGS) -I$(PYTHIA8LOCATION)/$(INCDIR) $@.cc -o $(BINDIR)/$@.exe \
+ 	-L$(PYTHIA8LOCATION)/$(LIBDIRARCH) -lpythia8 $(LIBGZIP) \
+-	-L$(LHAPDFLOCATION) $(LHAPDFLIBNAME) \
+-	$(FLIBS)
++	-L$(LHAPDFLOCATION) $(LHAPDFLIBNAME)
+ 	@ln -fs $(BINDIR)/$@.exe $@.exe
+ 
+ # Create an executable that links to LHAPDF and HepMC
+@@ -76,8 +75,7 @@ main61 main62 main85 main86 main87 main8
+ 	$@.cc -o $(BINDIR)/$@.exe \
+ 	-L$(PYTHIA8LOCATION)/$(LIBDIRARCH) -lpythia8 -lpythia8tohepmc $(LIBGZIP) \
+ 	-L$(LHAPDFLOCATION) $(LHAPDFLIBNAME) \
+-	-L$(HEPMCLOCATION)/lib -lHepMC \
+-	$(FLIBS)
++	-L$(HEPMCLOCATION)/lib -lHepMC
+ 	@ln -fs $(BINDIR)/$@.exe $@.exe
+ 
+ # Create an executable that links to Fastjet
+@@ -121,7 +119,7 @@ ifneq (x$(FASTJETLOCATION),x)
+ 	-lpythia8tohepmc \
+ 	-L$(HEPMCLOCATION)/lib -lHepMC \
+ 	-L$(FASTJETLOCATION)/lib \
+-	-L$(LHAPDFLOCATION)/lib \
++	-L$(LHAPDFLOCATION) \
+ 	`$(FASTJETLOCATION)/bin/fastjet-config --libs --plugins`
+ 	@ln -fs $(BINDIR)/$@.exe $@.exe
+ 	@rm -f $@.o

--- a/pkgs/PYTHIA8/src-unpacked.nix
+++ b/pkgs/PYTHIA8/src-unpacked.nix
@@ -1,15 +1,16 @@
 { stdenv, PYTHIA8-src }:
- 
-stdenv.mkDerivation rec { 
-  name = "PYTHIA8-src-unpacked-${version}"; 
-  version = "180";
+
+stdenv.mkDerivation rec {
+  name = "PYTHIA8-src-unpacked-${version}";
+  version = "186";
   src = PYTHIA8-src;
+  patches = [ ./lhapdf6.patch ];
   buildInputs = [];
-  enableParallelBuilding = true; 
-  phases = [ "unpackPhase" "installPhase" ] ;  
-  installPhase = '' 
+  enableParallelBuilding = true;
+  phases = [ "unpackPhase" "patchPhase" "installPhase" ] ;
+  installPhase = ''
     cd ..
     mkdir $out
-    cp -a pythia8180/* $out/
-  ''; 
+    cp -a pythia8186/* $out/
+  '';
 }

--- a/pkgs/PYTHIA8/src.nix
+++ b/pkgs/PYTHIA8/src.nix
@@ -1,6 +1,6 @@
 { fetchurl }:
 
-fetchurl { 
-    url = "http://home.thep.lu.se/~torbjorn/pythia8/pythia8180.tgz";
-    sha256 = "1w1x0g14h8pj03gzkbfa6yi6cl3mavgbnv9s6dg07265pppycg3w";
+fetchurl {
+    url = "http://home.thep.lu.se/~torbjorn/pythia8/pythia8186.tgz";
+    sha256 = "1llv0c4x1b7v1bj7lh54mzck92yl7i558fxdq4ifj7l00ky1828w";
 }


### PR DESCRIPTION
This is to test LHAPDF6 for PYTHIA8. Since LHAPDF6 does not depend on gfortran, it is possible to be built in OS X, where gfortran still fails to build. The patch is to remove the link to the fortran library, such as `-lg2c`, in PYTHIA8. The link is not necessary when using LHAPDF6. Accordingly, PYTHIA8Env has been modified.

It also updates to the version 8.186.

I have tested on OS X only, but I expect that it would also be fine in Linux.

If it is successful, I will try Herwig++ in the similar way.