### PR TITLE
Add LUXCalc

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -77,6 +77,10 @@ rec {
 
       LHAPDF6       = callPackage ./pkgs/LHAPDF6 { };
 
+      LUXCalc       = callPackage ./pkgs/LUXCalc { };
+
+      LUXCalcEnv    = callPackage ./pkgs/LUXCalc/env.nix { inherit LUXCalc; };
+
       MadAnalysis5  = callPackage ./pkgs/MadAnalysis5 { };
 
       MadAnalysis5Env  = callPackage ./pkgs/MadAnalysis5/env.nix {

--- a/pkgs/LUXCalc/compiler.patch
+++ b/pkgs/LUXCalc/compiler.patch
@@ -1,0 +1,14 @@
+diff -rupN a/Makefile b/Makefile
+--- a/Makefile	2015-01-27 19:41:48.000000000 +0900
++++ b/Makefile	2015-02-12 00:47:21.961162409 +0900
+@@ -43,8 +43,8 @@ LUXCALC_VERSION=$(shell grep "VERSION_ST
+ #FFLAGS := -fast
+ 
+ # GNU fortran compiler
+-#FC := gfortran
+-#FFLAGS := -O3 -fno-range-check
++FC := gfortran
++FFLAGS := -O3 -fno-range-check
+ 
+ # Command used to search for ifort or gfortran compiler.
+ # Gives an error if neither is found.

--- a/pkgs/LUXCalc/default.nix
+++ b/pkgs/LUXCalc/default.nix
@@ -1,0 +1,28 @@
+{ pkgs, fetchurl }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "LUXCalc-${version}";
+  version = "1.1.0";
+  src = fetchurl {
+    url = "http://www.nordita.org/~savage/LUXCalc/LUXCalc-1.0.0.tar.gz";
+    sha256 = "1fr971mc93vwhs6j5a5vy053wbjbsyv0hvrp4swrkdxzq323mdx2";
+  };
+  buildInputs = [ pkgs.gfortran ];
+  patches = [ ./compiler.patch ];
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    cd ..
+    tar czf ${name}.tar.gz $sourceRoot
+    mkdir -p $out/share/${name}
+    cp ${name}.tar.gz $out/share/${name}
+  '';
+
+  meta = {
+  };
+}

--- a/pkgs/LUXCalc/env.nix
+++ b/pkgs/LUXCalc/env.nix
@@ -1,0 +1,15 @@
+{ pkgs, LUXCalc }:
+
+let version = LUXCalc.version;
+in pkgs.myEnvFun rec {
+  name = "LUXCalc-${version}";
+
+  buildInputs = with pkgs; [ ];
+
+  extraCmds = with pkgs; ''
+    unpack () {
+      tar xzf ${LUXCalc}/share/${name}/${name}.tar.gz
+    }
+    export -f unpack
+  '';
+}


### PR DESCRIPTION
This adds [LUXCalc](http://www.nordita.org/~savage/LUXCalc/index.html), which provides the means to easily calculate dark matter direct detection likelihoods and cross-section limits for the LUX 2013 experimental result.

It was only tested on Linux since gfortran is still not available in OS X.