### PR TITLE
Update SPheno (3.3.5)

### DIFF
--- a/pkgs/SPheno/default.nix
+++ b/pkgs/SPheno/default.nix
@@ -4,10 +4,10 @@ with pkgs;
 
 stdenv.mkDerivation rec {
   name = "SPheno-${version}";
-  version = "3.3.3";
+  version = "3.3.5";
   src = fetchurl {
-    url = "http://www.hepforge.org/archive/spheno/SPheno-3.3.3.tar.gz";
-    sha256 = "11x34hc0scm0sfm95a3i548ihh9dvd9pk0xzx9vxn5m0sa38aszl";
+    url = "http://www.hepforge.org/archive/spheno/SPheno-3.3.5.tar.gz";
+    sha256 = "0nisc67qlhc5cfrfbjill1bmsyn8maxdlkj3varxqfwzxn7bwcg0";
   };
   patches = [ ./use-gfortran.patch ];
   buildInputs = [ gfortran ];

--- a/pkgs/SPheno/use-gfortran.patch
+++ b/pkgs/SPheno/use-gfortran.patch
@@ -1,12 +1,16 @@
 diff -rupN a/Makefile b/Makefile
---- a/Makefile	2014-05-19 14:40:35.000000000 +0000
-+++ b/Makefile	2014-08-26 13:04:35.000000000 +0000
-@@ -6,7 +6,7 @@
- # F90 = gfortran
+--- a/Makefile	2015-02-20 17:49:33.000000000 +0900
++++ b/Makefile	2015-02-25 17:04:25.000000000 +0900
+@@ -3,10 +3,10 @@
+ # cases NAG's nagfor, gfortran, g95, Lahey's lf95 and Intels ifort
+ # Please uncomment the corresponding line
+ # F90 = nagfor
+-# F90 = gfortran
++F90 = gfortran
  # F90 = g95
  # F90 = lf95
 -F90 = ifort
-+F90 = gfortran
++# F90 = ifort
  Model = src
  version = 330.00
  bin/SPheno:


### PR DESCRIPTION
This updates `SPheno`. The most recent version is 3.3.5.

It has been tested on Linux.