### PR TITLE
Add TSIL

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -137,6 +137,8 @@ rec {
                         inherit HepMC LHAPDF FastJet libyamlcppPIC;
                       };
 
+      TSIL          = callPackage ./pkgs/TSIL { };
+
       YODA          = callPackage ./pkgs/YODA { };
 
       cernlib       = callPackage ./pkgs/cernlib { };

--- a/pkgs/TSIL/compiler.patch
+++ b/pkgs/TSIL/compiler.patch
@@ -1,0 +1,12 @@
+diff -rupN a/Makefile b/Makefile
+--- a/Makefile	2014-05-31 12:24:14.000000000 +0900
++++ b/Makefile	2015-03-13 15:45:33.000000000 +0900
+@@ -23,7 +23,7 @@
+ #
+ # GNU C Compiler:
+ # ===============
+- CC		= gcc
++ CC		= cc
+  TSIL_OPT	= -O3 -funroll-loops 
+ #
+ ################### INSTALLATION DIRECTORIES #######################

--- a/pkgs/TSIL/default.nix
+++ b/pkgs/TSIL/default.nix
@@ -1,0 +1,28 @@
+{ pkgs, fetchurl }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "TSIL-${version}";
+  version = "1.21";
+  src = fetchurl {
+    url = "http://www.niu.edu/spmartin/TSIL/tsil-1.21.tar.gz";
+    sha256 = "0pr6gvfs3wv53h682wzjs1zl8h5gmydqa5v7h7ii79byas43lfyj";
+  };
+  buildInputs = [ ];
+  patches = [ ./compiler.patch ];
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/lib
+    mkdir -p $out/include
+    cp -a libtsil.a $out/lib
+    cp -a tsil.h $out/include
+  '';
+
+  meta = {
+  };
+}


### PR DESCRIPTION
This adds [TSIL](http://www.niu.edu/spmartin/TSIL/), a library of utilities for the numerical calculation of dimensionally regularized two-loop self-energy integrals.

It was tested on OS X.