### PR TITLE
Add SMH

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -125,6 +125,8 @@ rec {
 
       SHERPA        = callPackage ./pkgs/SHERPA { };
 
+      SMH           = callPackage ./pkgs/SMH { inherit TSIL; };
+
       SPheno        = callPackage ./pkgs/SPheno { };
 
       SUSY-HIT      = callPackage ./pkgs/SUSY-HIT { };

--- a/pkgs/SMH/compiler.patch
+++ b/pkgs/SMH/compiler.patch
@@ -1,0 +1,20 @@
+Binary files a/._README.txt and b/._README.txt differ
+Binary files a/._effpot.c and b/._effpot.c differ
+Binary files a/._fig_Mh_vs_Q.c and b/._fig_Mh_vs_Q.c differ
+Binary files a/._fig_lambda_vs_Q.c and b/._fig_lambda_vs_Q.c differ
+Binary files a/._fig_m2_vs_Q.c and b/._fig_m2_vs_Q.c differ
+Binary files a/._fig_vev_vs_Q.c and b/._fig_vev_vs_Q.c differ
+Binary files a/._smhtest.c and b/._smhtest.c differ
+Binary files a/._tsil.h and b/._tsil.h differ
+diff -rupN a/Makefile b/Makefile
+--- a/Makefile	2014-07-15 17:02:13.000000000 +0200
++++ b/Makefile	2015-03-18 13:19:38.000000000 +0100
+@@ -22,7 +22,7 @@
+ #
+ # GNU C Compiler:
+ # ===============
+- CC		= gcc
++ CC		= cc
+  SMH_OPT 	= -O2
+ #
+ ####################################################################

--- a/pkgs/SMH/default.nix
+++ b/pkgs/SMH/default.nix
@@ -1,0 +1,30 @@
+{ pkgs, fetchurl, TSIL }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "SMH-${version}";
+  version = "1.0";
+  src = fetchurl {
+    url = "http://www.niu.edu/spmartin/smh/smh-1.0.tar.gz";
+    sha256 = "06nwgbpz0wc9sq14m0im9v31l1qpw7a9hc09y6lrnjfci27prypx";
+  };
+  buildInputs = [ TSIL ];
+  patches = [ ./compiler.patch ];
+
+  buildPhase = ''
+    make
+  '';
+
+  installPhase = ''
+    mkdir -p $out/bin
+    cp -a smh.tst calc_Mh calc_lambda calc_vev calc_m2 rgrun fig_vev_vs_Q fig_m2_vs_Q fig_Mh_vs_Q fig_lambda_vs_Q $out/bin
+    mkdir -p $out/include
+    cp -a smhiggs.h $out/include
+    mkdir -p $out/lib
+    cp -a libsmh.a $out/lib
+  '';
+
+  meta = {
+  };
+}


### PR DESCRIPTION
This adds [SMH](http://www.niu.edu/spmartin/SMH/), which provides a library of utilities for calculations involving the Higgs sector of the Standard Model.

It has been tested on OS X.