### PR TITLE
Add SARAH

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -59,7 +59,7 @@ rec {
 
       FeynRules     = callPackage ./pkgs/FeynRules { };
 
-      FeynRulesEnv  = callPackage ./pkgs/FeynRules/env.nix { 
+      FeynRulesEnv  = callPackage ./pkgs/FeynRules/env.nix {
                         inherit FeynRules;
                       };
 
@@ -125,6 +125,12 @@ rec {
 
       ROOT6Env      = callPackage ./pkgs/ROOT6/env.nix {
                         inherit ROOT6;
+                      };
+
+      SARAH         = callPackage ./pkgs/SARAH { };
+
+      SARAHEnv      = callPackage ./pkgs/SARAH/env.nix {
+                        inherit SARAH;
                       };
 
       SHERPA        = callPackage ./pkgs/SHERPA { };

--- a/pkgs/SARAH/default.nix
+++ b/pkgs/SARAH/default.nix
@@ -1,0 +1,22 @@
+{ pkgs }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "SARAH";
+  version = "4.5.3";
+  src = fetchurl {
+    url = "http://www.hepforge.org/archive/sarah/SARAH-4.5.3.tar.gz";
+    sha256 = "18v01ckpxqs1x21n90cys6l6v9956j6k1aqdv6dan92384yk9ynv";
+  };
+
+  installPhase = ''
+    cd ..
+    tar cvzf ${name}-${version}.tar.gz ${name}-${version}
+    mkdir -p $out/share/${name}-${version}
+    cp -a ${name}-${version}.tar.gz $out/share/${name}-${version}
+  '';
+
+  meta = {
+  };
+}

--- a/pkgs/SARAH/env.nix
+++ b/pkgs/SARAH/env.nix
@@ -1,0 +1,18 @@
+{ pkgs, SARAH }:
+
+let version = SARAH.version;
+in pkgs.myEnvFun rec {
+  name = "SARAH-${version}";
+
+  buildInputs = with pkgs; [ ];
+
+  extraCmds = with pkgs; ''
+    unpack () {
+      dir=\$(pwd)
+      str='\$Path = AppendTo[ \$Path, "'\$dir'"];'
+      echo \$str > init.m
+      tar xvzf ${SARAH}/share/SARAH-${version}/SARAH-${version}.tar.gz
+    }
+    export -f unpack
+  '';
+}


### PR DESCRIPTION
This adds [SARAH](https://sarah.hepforge.org), a Mathematica package for building and analyzing SUSY and non-SUSY models.

Since its official [manual](http://arxiv.org/abs/0806.0538) says to run SARAH as

```Mathematica
<<"[SARAH Directory]/SARAH.m"
```

the working directory alone is append to `$Path`.