### PR TITLE
FeynHiggs: 2.10.2 -> 2.10.3

### DIFF
--- a/pkgs/FeynHiggs/default.nix
+++ b/pkgs/FeynHiggs/default.nix
@@ -1,11 +1,13 @@
-{ stdenv, fetchurl, pkgs }:
+{ pkgs }:
+
+with pkgs;
 
 stdenv.mkDerivation rec {
   name = "FeynHiggs-${version}";
-  version = "2.10.2";
+  version = "2.10.3";
   src = fetchurl {
-    url = "http://wwwth.mpp.mpg.de/members/heinemey/feynhiggs/newversion/FeynHiggs-2.10.2.tar.gz";
-    sha256 = "1977jnxp9a43kf5qndcxap05wpi028v6bx27xx5qhbqv0di23mjq";
+    url = "http://wwwth.mpp.mpg.de/members/heinemey/feynhiggs/newversion/FeynHiggs-2.10.3.tar.gz";
+    sha256 = "0gj2hi5yzvjwawx10gmbmm5fhcjnqk3crqqax21hqwikllhkags9";
    };
   buildInputs = [ pkgs.gfortran pkgs.which ];
   enableParallelBuilding = true;
@@ -14,7 +16,7 @@ stdenv.mkDerivation rec {
     substituteInPlace configure --replace /bin/sh ${pkgs.bash}/bin/bash
   '';
 
-  configureFlags = "--64"; # if stdenv.isDarwin then "--64" else "";
+  configureFlags = "--64";
 
   meta = {
   };


### PR DESCRIPTION
This updates `FeynHiggs' from 2.10.2 to 2.10.3.

Its has been tested on OS X. I think that it will work if `gfortran` is available.