### PR TITLE
YODA: 1.3.0 -> 1.3.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -103,8 +103,8 @@ rec {
                               };
 
       Rivet         = callPackage ./pkgs/Rivet {
-                        inherit HepMC FastJet;
-                        inherit libyamlcppPIC ;
+                        inherit HepMC FastJet YODA;
+                        inherit libyamlcppPIC;
                       };
 
       PYTHIA8-src   = callPackage ./pkgs/PYTHIA8/src.nix { };

--- a/pkgs/YODA/default.nix
+++ b/pkgs/YODA/default.nix
@@ -1,24 +1,24 @@
-{ stdenv, fetchurl, boost, python }:
+{ pkgs }:
+
+with pkgs;
 
 stdenv.mkDerivation rec {
   name = "YODA-${version}";
-  version = "1.3.0";
+  version = "1.3.1";
 
   src = fetchurl {
-    url = "http://www.hepforge.org/archive/yoda/YODA-1.3.0.tar.bz2";
-    sha256 = "05fj5cqq06qdb2pcqqdd5krqi4xlq3ch6iyg0v5iwj0bjkarfcfn";
+    url = "http://www.hepforge.org/archive/yoda/YODA-1.3.1.tar.bz2";
+    sha256 = "0iwppj9m8bv6qd5kdhqyqais2g31x5nqgnzjs5nsqfly01nijki7";
   };
 
   buildInputs = [ boost python ];
   enableParallelBuilding = true;
 
-  preConfigure = '' 
-    substituteInPlace include/YODA/Utils/BinSearcher.h --replace "isinf" "std::isinf" --replace "isnan" "std::isnan"
-  '' 
-  + (if (stdenv.isDarwin) then ''
-    substituteInPlace pyext/setup.py.in --replace "stdc++" "c++" 
+  preConfigure = if stdenv.isDarwin then ''
+    substituteInPlace pyext/setup.py.in --replace "stdc++" "c++"
   ''
-  else "");
+    else ''
+  '';
 
   configureFlags = "--with-boost=${boost.dev}";
 


### PR DESCRIPTION
This updates `YODA`.

The patches on `isinf` and `isnan` are no more necessary because it was fixed in the upstream. And, the dependency on `YODA` is added in `Rivet`.

It has been tested on OS X.