### PR TITLE
SHERPA: 2.0.0 -> 2.1.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -133,7 +133,9 @@ rec {
                         inherit SARAH;
                       };
 
-      SHERPA        = callPackage ./pkgs/SHERPA { };
+      SHERPA        = callPackage ./pkgs/SHERPA {
+                        inherit HepMC FastJet;
+                      };
 
       SMH           = callPackage ./pkgs/SMH { inherit TSIL; };
 

--- a/pkgs/SHERPA/default.nix
+++ b/pkgs/SHERPA/default.nix
@@ -1,12 +1,16 @@
-{ stdenv, fetchurl, gfortran }:
- 
-stdenv.mkDerivation rec { 
-  name = "SHERPA-${version}"; 
-  version = "2.0.0";
-  src = fetchurl { 
-    url = "http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.0.0.tar.gz";
-    sha256 = "0mv5p6d0zgif3iz5jwrwl2lbdchd59bp55ahm84l9kla2bmbb27a";
+{ pkgs, HepMC, FastJet }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "SHERPA-${version}";
+  version = "2.1.1";
+  src = fetchurl {
+    url = "https://www.hepforge.org/archive/sherpa/SHERPA-MC-2.1.1.tar.gz";
+    sha256 = "0s38d66wd6mk2sxnipzrrcf3d3j2hw985vwawvipbppwxap9m04s";
   };
-  buildInputs = [ gfortran ];
-  #configureFlags = "--with-thepeg=${ThePEG} --with-fastjet=${FastJet} ";
+  buildInputs = [ gfortran sqlite zlib ];
+  enableParallelBuilding = true;
+
+  configureFlags = "--disable-pyext --enable-hepmc2=${HepMC} --enable-fastjet=${FastJet} --enable-gzip --with-sqlite3=${sqlite}";
 }


### PR DESCRIPTION
This updates `SHERPA`.

The dependencies on `HepMC` and `FastJet` have been added. `configureFlags` has been also added.

It was built successfully on OS X.