### PR TITLE
Add Minuit2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -102,6 +102,8 @@ rec {
                                 inherit pythia-pgs MadGraph5_aMCatNLO ; # PYTHIA8-src;
                               };
 
+      Minuit2       = callPackage ./pkgs/Minuit2 { };
+
       Rivet         = callPackage ./pkgs/Rivet {
                         inherit HepMC FastJet YODA;
                         inherit libyamlcppPIC;

--- a/pkgs/Minuit2/default.nix
+++ b/pkgs/Minuit2/default.nix
@@ -1,0 +1,15 @@
+{ pkgs }:
+
+with pkgs;
+
+stdenv.mkDerivation rec {
+  name = "Minuit2-${version}";
+  version = "5.34.14";
+  src = fetchurl {
+    url = "http://www.cern.ch/mathlibs/sw/5_34_14/Minuit2/Minuit2-5.34.14.tar.gz";
+    sha256 = "0mn3m050m78mwmb7hks9z58zvs67fk5w8arj1960c5f3pf1s5a9c";
+  };
+  buildInputs = [ ];
+  patches = [ ];
+  enableParallelBuilding = true;
+}


### PR DESCRIPTION
This adds [Minuit2](http://seal.web.cern.ch/seal/work-packages/mathlibs/minuit/), which is a standalone Minuit2 library.

If this would be successful, we may try `pyminuit2` using this standalone.

It has been tested on OS X.